### PR TITLE
Prevent TLoad() from loading a template if the buffer is not empty.

### DIFF
--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -144,6 +144,10 @@ endfunction
 " cursor at %HERE%. Used to implement the BufNewFile autocommand.
 "
 function <SID>TLoad()
+	if len(getline(1, '$')) == 1 && empty(getline(1))
+		return
+	endif
+
 	let l:file_ext = expand("%:e")
 	if l:file_ext == ""
 		let l:file_ext = expand("%:t")


### PR DESCRIPTION
Hi,

I'd like to thank you for this nice plugin. Me and some other Vim users are using your plugin as the template engine for a plugin(1) that provides some help with Vim plugins development. We thought on implementing our own engine, but yours is a great fit for our needs.

The only issue we had so far is that on `*.txt` files `TLoad()` is fired after we already filled the buffer with `:Template`. The problem with that is that we can't find a reliable way to remove the 'extra' text added by `TLoad()`.

This pull request tries to fix that. Please, let me know if you like it, I'll be more than happy to work on a solution that you'd find acceptable.

Cheers!
Israel

(1) https://github.com/dahu/Area-41
