### PR TITLE
I modified the default HTML template 

### DIFF
--- a/templates/template.html
+++ b/templates/template.html
@@ -1,12 +1,10 @@
 <!DOCTYPE html>
 <html>
 	<head>
+        <meta charset="utf-8" />
 		<title>%FILE%</title>
-		<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
 	</head>
 	<body>
 		%HERE%
 	</body>
 </html>
-<!-- vim:fenc=utf-8
-  -->


### PR DESCRIPTION
The charset meta should put before the title . And can write like this: 
`<meta charset="utf-8" />`
It's more short than before.

And I delete the html template comment , I think most people will delete this comment after import this template.
