### PR TITLE
PHPDoc enhancements in php template

### DIFF
--- a/templates/template.php
+++ b/templates/template.php
@@ -2,14 +2,11 @@
 /**
  * Short description for %FFILE%
  *
- * Copyright (C) %YEAR% %USER% <%MAIL%>
- *
- * Distributed under terms of the MIT license.
- *
  * @package %FILE%
  * @author %USER% <%MAIL%>
  * @version 0.1
  * @copyright (C) %YEAR% %USER% <%MAIL%>
+ * @license MIT    
  */
 
 %HERE%


### PR DESCRIPTION
Hello there,

some few simplifications inside the initial phpdoc block:
- moving license citation into an appropriate @licence tag (see http://www.phpdoc.org/docs/latest/for-users/phpdoc/tags/license.html)
- removing the copyright statement redundancy
