### PR TITLE
Remove underscores from header guard

### DIFF
--- a/templates/template.h
+++ b/templates/template.h
@@ -5,9 +5,9 @@
  * Distributed under terms of the %LICENSE% license.
  */
 
-#ifndef __%GUARD%__
-#define __%GUARD%__
+#ifndef %GUARD%
+#define %GUARD%
 
 %HERE%
 
-#endif /* !__%GUARD%__ */
+#endif /* !%GUARD% */


### PR DESCRIPTION
According to various sources, variable names prepended with underscores are reserved for compilers.

See [here](https://www.securecoding.cert.org/confluence/display/seccode/DCL37-C.+Do+not+declare+or+define+a+reserved+identifier#DCL37-C.Donotdeclareordefineareservedidentifier-NoncompliantCodeExample%28HeaderGuard%29) and [here](http://punchlet.wordpress.com/2009/12/01/letter-the-second/)
