### PR TITLE
Fixed extra line after template

### DIFF
--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -204,6 +204,8 @@ function <SID>TLoad()
 		" Read template file and expand variables in it.
 		execute "0r " . l:tFile
 		call <SID>TExpandVars()
+		" This leaves an extra blank line at the bottom, delete it
+		execute line('$') . "d"
 		call <SID>TPutCursor()
 		setlocal nomodified
 	endif
@@ -227,6 +229,7 @@ function <SID>TLoadCmd(template)
 	if l:tFile != ""
 		execute "0r " . l:tFile
 		call <SID>TExpandVars()
+		execute line('$') . "d"
 		call <SID>TPutCursor()
 	endif
 endfunction


### PR DESCRIPTION
Because a new file in vim technically starts with a single undeletable line, inserting a template results in that line being leftover, so there is always an extra empty line after the template in a new file. This deletes that line after the variables are expanded (couldn't figure out a better way to do this, I'm pretty sure there isn't one).
