### PR TITLE
FIXED alt file is set to template file

### DIFF
--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -389,7 +389,7 @@ function <SID>TLoadTemplate(template)
 	if a:template != ""
 		" Read template file and expand variables in it.
 		let l:safeFileName = <SID>NeuterFileName(a:template)
-		execute "0r " . l:safeFileName
+		execute "keepalt 0r " . l:safeFileName
 		call <SID>TExpandVars()
 		" This leaves an extra blank line at the bottom, delete it
 		execute line('$') . "d"


### PR DESCRIPTION
When creating a new file the alternative file name was set to the template file (because of the :read operation).
Added "keepalt" command to prevent overriding  alternative buffer name
