### PR TITLE
Support filenames containing two extensions

### DIFF
--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -305,7 +305,7 @@ function <SID>TExpandVars()
 	let l:date       = exists("g:dateformat") ? strftime(g:dateformat) :
 				     \ (l:year . "-" . l:month . "-" . l:day)
 	let l:fdate      = l:date . " " . l:time
-	let l:filen      = expand("%:t:r")
+	let l:filen      = expand("%:t:r:r:r")
 	let l:filex      = expand("%:e")
 	let l:filec      = expand("%:t")
 	let l:fdir       = expand("%:p:h:t")


### PR DESCRIPTION
e:g: If filename is Foo.class.cpp, %CLASS% will then be `Foo` instead of `Foo.Class`