### PR TITLE
Allow users to define custom variables to expand

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,10 @@ In your vimrc you can put:
 * ``let g:templates_no_builtin_templates = 1`` to disable usage of the
   built-in templates. See `template search order`_ below for more details.
 
+* ``let g:templates_user_variables = [[USERVAR, UserFunc]]`` to enable
+  user-defined variable expanding. See `User-defined variable expanding`_
+  below for details.
+
 
 Usage
 =====
@@ -163,4 +167,23 @@ The following variables will be expanded in templates:
 ``%HERE%``
     Expands to nothing, but ensures that the cursor will be placed in its
     position after expanding the template.
+
+User-defined variable expanding
+-------------------------------
+
+You can set ``g:templates_user_variables`` to expand custom variables. It should
+be something like ``[['USERVAR1', 'UserFunc1'], ['USERVAR2', 'UserFunc2']]``,
+where ``USERVAR1`` is the variable to be expanded and ``UserFunc1`` is the name of
+the function that returns the result. The function should take no arguments and
+return the string after expansion.
+
+Example:::
+
+    let g:templates_user_variables = [['FULLPATH', 'GetFullPath']]
+    function GetFullPath()
+        return expand('%:p')
+    endfunction
+
+And each occurrence of ``%FULLPATH%`` in template will be replaced with the full
+path of current file.
 

--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -50,6 +50,10 @@ if !exists('g:templates_no_builtin_templates')
 	let g:templates_no_builtin_templates = 0
 endif
 
+if !exists('g:templates_user_variables')
+	let g:templates_user_variables = []
+endif
+
 " Put template system autocommands in their own group. {{{1
 if !exists('g:templates_no_autocmd')
 	let g:templates_no_autocmd = 0
@@ -337,6 +341,12 @@ function <SID>TExpandVars()
 	call <SID>TExpand("MACROCLASS", l:macroclass)
 	call <SID>TExpand("CAMELCLASS", l:camelclass)
 	call <SID>TExpand("LICENSE", exists("g:license") ? g:license : "MIT")
+
+	" Perform expansions for user-defined variables
+	for [l:varname, l:funcname] in g:templates_user_variables
+		let l:value = function(funcname)()
+		call <SID>TExpand(l:varname, l:value)
+	endfor
 endfunction
 
 " }}}2


### PR DESCRIPTION
So users can expand custom `%XXX%` variables into custom results with `g:templates_user_variables`.