### PR TITLE
Fix find command ignore symbolic links file issues.

### DIFF
--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -196,7 +196,7 @@ function <SID>TDirectorySearch(path, template_prefix, file_name)
 	" Use find if possible as it will also get hidden files on nix systems. Use
 	" builtin glob as a fallback
 	if executable("find") && !has("win32") && !has("win64")
-		let l:find_cmd = '`find ''' . a:path . ''' -maxdepth 1 -name ''' . a:template_prefix . '*''`'
+		let l:find_cmd = '`find -L ''' . a:path . ''' -maxdepth 1 -type f -name ''' . a:template_prefix . '*''`'
 		call <SID>Debug("Executing " . l:find_cmd)
 		let l:glob_results = glob(l:find_cmd)
 	else

--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -196,7 +196,7 @@ function <SID>TDirectorySearch(path, template_prefix, file_name)
 	" Use find if possible as it will also get hidden files on nix systems. Use
 	" builtin glob as a fallback
 	if executable("find") && !has("win32") && !has("win64")
-		let l:find_cmd = '`find ''' . a:path . ''' -maxdepth 1 -type f -name ''' . a:template_prefix . '*''`'
+		let l:find_cmd = '`find ''' . a:path . ''' -maxdepth 1 -name ''' . a:template_prefix . '*''`'
 		call <SID>Debug("Executing " . l:find_cmd)
 		let l:glob_results = glob(l:find_cmd)
 	else


### PR DESCRIPTION
The current result of `find` command will ignore some symbolic links since it has the option `-type f`.
> ./=template=.pro
./=template=.sh
./=template=.rs
./=template=.cmake
./=template=.pl
./=template=.bash
./=template=.robots.txt
./=template=.lua
./=template=.html
./=template=.jl
./=template=.rb
./=template=.css
./=template=.ml
./=template=.js
./=template=.go
./=template=.f90
./=template=.sql
./=template=.pm
./=template=.dart
./=template=.coffee
./=template=.f
./=template=.txt
./=template=.java
./=template=.h
./=template=.humans.txt
./=template=.hs
./=template=.lhs
./=template=.tex
./=template=.c
./=template=.xsl
./=template=.php
./=template=.xml
./=template=.pls
./=template=Makefile
./=template=.zcml
./=template=.py

some files like =template=.cpp =template=.c++ will be ignored since they are symbolic links to another file.
> =template=.cpp -> =template=.c

Removing `-type f` will make these ignored files appear again in the result.