### PR TITLE
Fix current register being deleted by "d" command.

### DIFF
--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -452,7 +452,7 @@ function <SID>TLoadTemplate(template)
 
 		if l:deleteLastLine == 1
 			" Loading a template into an empty buffer leaves an extra blank line at the bottom, delete it
-			execute line('$') . "d"
+			execute line('$') . "d _"
 		endif
 
 		call <SID>TPutCursor()


### PR DESCRIPTION
Adding "_" after d command delete it in the blak hole register and avoid losing current register, which might be annoying when creating a new file to paste part of another one.