### PR TITLE
Add command to insert the specified template under the cursor

### DIFF
--- a/doc/template.txt
+++ b/doc/template.txt
@@ -44,8 +44,9 @@ the `g:templates_no_autocmd` variable.
 ===========================================================================
 COMMANDS                                              *template-commands*
 
-The plug-in defines a single command, which expands a template in the
-current buffer. Its syntax is:
+The plug-in defines two commands, both of which expand a template in the
+current buffer. The first expands a matched template at the beginning of
+the current buffer. Its syntax is:
 
 *:Template* <pattern>
 
@@ -57,6 +58,12 @@ expanded into the current buffer. For example:
 will expand the local template `.vim-template:*.c`, or the global template
 `template:*.c`, whichever is found first (see |templates-search-order|
 for more information).
+
+The second command works exactly the same except that it will expand a matched
+template under the cursor instead of at the beginning of the buffer. Its syntax
+is:
+
+*:TemplateHere* <pattern>
 
 
 ===========================================================================

--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -414,7 +414,7 @@ function <SID>TLoad()
 	let l:file_dir = <SID>DirName(l:file_name)
 	let l:depth = g:templates_search_height
 	let l:tFile = <SID>TFind(l:file_dir, l:file_name, l:depth)
-	call <SID>TLoadTemplate(l:tFile)
+	call <SID>TLoadTemplate(l:tFile, 0)
 endfunction
 
 
@@ -423,7 +423,7 @@ endfunction
 " a template suffix (and the template is searched as usual). Of course this
 " makes variable expansion and cursor positioning.
 "
-function <SID>TLoadCmd(template)
+function <SID>TLoadCmd(template, position)
 	if filereadable(a:template)
 		let l:tFile = a:template
 	else
@@ -434,11 +434,11 @@ function <SID>TLoadCmd(template)
 
 		let l:tFile = <SID>TFind(l:file_dir, a:template, l:height)
 	endif
-	call <SID>TLoadTemplate(l:tFile)
+	call <SID>TLoadTemplate(l:tFile, a:position)
 endfunction
 
 " Load the given file as a template
-function <SID>TLoadTemplate(template)
+function <SID>TLoadTemplate(template, position)
 	if a:template != ""
 		let l:deleteLastLine = 0
 		if line('$') == 1 && getline(1) == ''
@@ -447,7 +447,11 @@ function <SID>TLoadTemplate(template)
 
 		" Read template file and expand variables in it.
 		let l:safeFileName = <SID>NeuterFileName(a:template)
-		execute "keepalt 0r " . l:safeFileName
+		if a:position == 0
+			execute "keepalt 0r " . l:safeFileName
+		else
+			execute "keepalt r " . l:safeFileName
+		endif
 		call <SID>TExpandVars()
 
 		if l:deleteLastLine == 1
@@ -475,7 +479,8 @@ fun ListTemplateSuffixes(A,P,L)
 
   return l:res
 endfun
-command -nargs=1 -complete=customlist,ListTemplateSuffixes Template call <SID>TLoadCmd("<args>")
+command -nargs=1 -complete=customlist,ListTemplateSuffixes Template call <SID>TLoadCmd("<args>", 0)
+command -nargs=1 -complete=customlist,ListTemplateSuffixes TemplateHere call <SID>TLoadCmd("<args>", 1)
 
 " Syntax autocommands {{{1
 "


### PR DESCRIPTION
Add a command :TemplateHere that will insert the resolved template under the cursor instead of at the beginning of the file. This is useful for setting up abbreviations that insert a template:

`:iabbrev rjscls <esc>:TemplateHere react-class.jsx<cr>i`

I'm new to vimscript so let me know if there's a better way to switch between the `0r` and `r` commands in `TLoadTemplate`.