### PR TITLE
Make `find` more robust

### DIFF
--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -215,6 +215,7 @@ function <SID>TDirectorySearch(path, template_prefix, file_name)
 			call <SID>Debug("Could not execute find command")
 			unlet l:glob_results
 		endif
+	endif
 	if !exists("l:glob_results")
 		call <SID>Debug("Using fallback glob")
 		let l:glob_results = glob(a:path . a:template_prefix . "*")

--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -208,10 +208,15 @@ function <SID>TDirectorySearch(path, template_prefix, file_name)
 	" Use find if possible as it will also get hidden files on nix systems. Use
 	" builtin glob as a fallback
 	if executable("find") && !has("win32") && !has("win64")
-		let l:find_cmd = '`find -L ''' . a:path . ''' -maxdepth 1 -type f -name ''' . a:template_prefix . '*''`'
+		let l:find_cmd = '`find -L ' . shellescape(a:path) . ' -maxdepth 1 -type f -name ' . shellescape(a:template_prefix . '*' ) . '`'
 		call <SID>Debug("Executing " . l:find_cmd)
 		let l:glob_results = glob(l:find_cmd)
-	else
+		if v:shell_error != 0
+			call <SID>Debug("Could not execute find command")
+			unlet l:glob_results
+		endif
+	if !exists("l:glob_results")
+		call <SID>Debug("Using fallback glob")
 		let l:glob_results = glob(a:path . a:template_prefix . "*")
 	endif
 	let l:templates = split(l:glob_results, "\n")


### PR DESCRIPTION
- Fallback to glob() if `find` encounters an error
- Ensure we properly escape input into `find`
  - i.e. if you were so inclined you can now have your templates in a
    directory with a single quote ' character
- Addresses #102 