### PR TITLE
Integrate nerdtree

### DIFF
--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -74,7 +74,7 @@ endif
 if !g:templates_no_autocmd
 	augroup Templating
 		autocmd!
-		autocmd BufNewFile * call <SID>TLoad()
+		autocmd BufNewFile,BufReadPost * call <SID>TLoad()
 	augroup END
 endif
 


### PR DESCRIPTION
Automatically call <SID>TLoad() when BufReadPost event occurs.
Relevant issue: [#17](https://github.com/aperezdc/vim-template/issues/17)
See more details here:
https://github.com/scrooloose/nerdtree/issues/617#issuecomment-249002351