### PR TITLE
deduplicate helptags `:Template` and `:TemplateHere`

### DIFF
--- a/doc/template.txt
+++ b/doc/template.txt
@@ -49,17 +49,17 @@ the `g:templates_no_autocmd` variable.
 
 
 ===========================================================================
-COMMANDS                                              *template-commands*
+COMMANDS                                  *:Template* *template-commands*
 
 The plug-in defines two commands, both of which expand a template in the
 current buffer. The first expands a matched template at the beginning of
 the current buffer. Its syntax is:
 
-*:Template*
+:Template
 
 or
 
-*:Template* <pattern>
+:Template <pattern>
 
 The <pattern> must be the same as for the template file that is to be
 expanded into the current buffer. For example:
@@ -70,15 +70,17 @@ will expand the local template `.vim-template:*.c`, or the global template
 `template:*.c`, whichever is found first (see |template-search-order|
 for more information).
 
+                                                          *:TemplateHere*
+
 The second command works exactly the same except that it will expand a matched
 template under the cursor instead of at the beginning of the buffer. Its syntax
 is:
 
-*:TemplateHere*
+:TemplateHere
 
 or
 
-*:TemplateHere* <pattern>
+:TemplateHere <pattern>
 
 
 ===========================================================================


### PR DESCRIPTION
helptags complains of multiple tags, when having asterisks around the same token more than once. see `:h :w` as an example, how to solve the issue of a token taking diffrent arguments

Signed-off-by: Florian Kerle <flo.kerle@gmx.at>