### PR TITLE
Automatically detect %LICENSE% using Licensee

### DIFF
--- a/doc/template.txt
+++ b/doc/template.txt
@@ -222,8 +222,10 @@ templates:
 		the `g:username` variable.
 
 `%LICENSE%`
-		Expands to the string `MIT` by default. May be overriden
-		by definining the `g:license` variable.
+		Tries to determine the project's license it the following order:
+		1. Using `licensee` if installed
+		2. Using the `g:license` variable.
+		3. If all else fails: Default to `MIT`.
 
 `%HOST%`
 		Current host name.

--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -359,7 +359,7 @@ function <SID>TExpandVars()
 	if executable('licensee')
 		" Returns 'None' if the project does not have a license.
 		let l:license = matchstr(system("licensee detect"), '^License:\s*\zs\S\+\ze\%x00')
-    endif
+	endif
 	if !exists("l:license") || l:license == "None"
 		if exists("g:license")
 			let l:license = g:license

--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -358,7 +358,7 @@ function <SID>TExpandVars()
 	" Define license variable
 	if executable('licensee')
 		" Returns 'None' if the project does not have a license.
-		let l:license = matchstr(system("licensee detect " . expand("%:p")), '^License:\s*\zs\S\+\ze\%x00')
+		let l:license = matchstr(system("licensee detect"), '^License:\s*\zs\S\+\ze\%x00')
     endif
 	if !exists("l:license") || l:license == "None"
 		if exists("g:license")

--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -355,6 +355,20 @@ function <SID>TExpandVars()
 	let l:macroclass = toupper(l:class)
 	let l:camelclass = substitute(l:class, "_", "", "g")
 
+	" Define license variable
+	if executable('licensee')
+		" Returns 'None' if the project does not have a license.
+		let l:license = matchstr(system("licensee detect " . expand("%:p")), \
+		'^License:\s*\zs\S\+\ze\%x00')
+    endif
+	if !exists("l:license") || l:license == "None"
+		if exists("g:license")
+			let l:license = g:license
+		else
+			let l:license = "MIT"
+		endif
+	endif
+
 	" Finally, perform expansions
 	call <SID>TExpand("DAY",   l:day)
 	call <SID>TExpand("YEAR",  l:year)
@@ -375,7 +389,7 @@ function <SID>TExpandVars()
 	call <SID>TExpand("CLASS", l:class)
 	call <SID>TExpand("MACROCLASS", l:macroclass)
 	call <SID>TExpand("CAMELCLASS", l:camelclass)
-	call <SID>TExpand("LICENSE", exists("g:license") ? g:license : "MIT")
+	call <SID>TExpand("LICENSE", l:license)
 
 	" Perform expansions for user-defined variables
 	for [l:varname, l:funcname] in g:templates_user_variables

--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -358,8 +358,7 @@ function <SID>TExpandVars()
 	" Define license variable
 	if executable('licensee')
 		" Returns 'None' if the project does not have a license.
-		let l:license = matchstr(system("licensee detect " . expand("%:p")), \
-		'^License:\s*\zs\S\+\ze\%x00')
+		let l:license = matchstr(system("licensee detect " . expand("%:p")), '^License:\s*\zs\S\+\ze\%x00')
     endif
 	if !exists("l:license") || l:license == "None"
 		if exists("g:license")


### PR DESCRIPTION
This pull request uses [`Licensee` by Ben Balter](https://github.com/benbalter/licensee) to automatically detect the license of the user's project if the Licensee executable is installed on their system. This is the project Github uses to determine a repository's license. `vim-template` should work as it does currently if Licensee is not found on the user's system.

Perhaps a configuration option should be added to make this feature optional?

There are still some problems so be dealt with:

- 3a5810a ('remove redundacy') needs to be reversed as it causes unexpected behavior if a file is opened from a 3rd directory
- benbalter/licensee#311
- benbalter/licensee#312
