### PR TITLE
Prevent potiential unintended behaviour with Licensee integration, allow for opt-out through configuration option

### DIFF
--- a/doc/template.txt
+++ b/doc/template.txt
@@ -136,6 +136,10 @@ plug-in:
 		|template-user-variables| for more details.
 		(Default: `[]`).
 
+`g:templates_use_licensee`
+		Use licensee to detect project license when expanding
+		`%LICENSE%`. (Default: `1`)
+
 `g:templates_debug`
 		If non-zero, output debugging information. (Default: `0`).
 
@@ -223,7 +227,8 @@ templates:
 
 `%LICENSE%`
 		Tries to determine the project's license it the following order:
-		1. Using `licensee` if installed
+		1. Using `licensee` if installed. This can be disabled by
+		setting the `g:templates_use_licensee` variable to `0`.
 		2. Using the `g:license` variable.
 		3. If all else fails: Default to `MIT`.
 

--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -66,6 +66,9 @@ if !exists('g:templates_user_variables')
 	let g:templates_user_variables = []
 endif
 
+if !exists('g:templates_use_licensee')
+	let g:templates_use_licensee = 0
+endif
 
 " Put template system autocommands in their own group. {{{1
 if !exists('g:templates_no_autocmd')
@@ -356,9 +359,9 @@ function <SID>TExpandVars()
 	let l:camelclass = substitute(l:class, "_", "", "g")
 
 	" Define license variable
-	if executable('licensee')
+	if executable('licensee') && g:templates_use_licensee
 		" Returns 'None' if the project does not have a license.
-		let l:license = matchstr(system("licensee detect"), '^License:\s*\zs\S\+\ze\%x00')
+		let l:license = matchstr(system("licensee detect " . expand("%:p:h")), '^License:\s*\zs\S\+\ze\%x00')
 	endif
 	if !exists("l:license") || l:license == "None"
 		if exists("g:license")


### PR DESCRIPTION
This pull request does two things:

1. Add configuration option to disable the use of Licensee through the use of the `g:templates_use_licensee` configuration option. I have yet to decide what the default value should be.

2. Fix potential unintended behaviour if vim is executed in a 3rd directory. As `system()` executes command in the directory it is started from, instead of the directory the file is in that is being edited.
```
let l:license = matchstr(system("licensee detect"), '^License:\s*\zs\S\+\ze\%x00')
```
is changed to
```
let l:license = matchstr(system("licensee detect " . expand("%:p:h")), '^License:\s*\zs\S\+\ze\%x00')
```