### PR TITLE
Add syntax highlighting for %LICENSE% tag

### DIFF
--- a/syntax/vim-template.vim
+++ b/syntax/vim-template.vim
@@ -12,7 +12,7 @@ if b:vim_template_subtype != ""
 	unlet b:current_syntax
 endif
 
-syn match vimtemplateVariable "%\%(DAY\|YEAR\|MONTH\|MONTHSHORT\|MONTHFULL\|DATE\|TIME\|FILE\|FFILE\|EXT\|MAIL\|USER\|HOST\|GUARD\|CLASS\|MACROCLASS\|CAMELCLASS\|HERE\)%" containedin=ALL
+syn match vimtemplateVariable "%\%(DAY\|YEAR\|MONTH\|MONTHSHORT\|MONTHFULL\|DATE\|TIME\|FILE\|FFILE\|EXT\|MAIL\|USER\|LICENSE\|HOST\|GUARD\|CLASS\|MACROCLASS\|CAMELCLASS\|HERE\)%" containedin=ALL
 
 let b:current_syntax = "vim-template"
 


### PR DESCRIPTION
This seems to have been forgotten in commit 08e144f, which introduced %LICENSE%.