### PR TITLE
Correctly detect Git repository license

### DIFF
--- a/doc/template.txt
+++ b/doc/template.txt
@@ -156,6 +156,13 @@ plug-in:
 		only the given directory is searched. If greater
 		than one, n parents and the given directory will be searched
 		where n is equal to height - 1. (Default: `-1`).
+`g:templates_detect_git`
+		Detects if the directory is in a Git repository and uses `git`
+		to determine the root of the repository. Licensee - if enabled
+		- is given the root directory instead of the one containing
+		the new file, since most Git repositories keep the license in
+		the root. Set to `1` to enable. May add half a second to
+		opening a new file.
 
 
 ===========================================================================

--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -70,6 +70,10 @@ if !exists('g:templates_use_licensee')
 	let g:templates_use_licensee = 1
 endif
 
+if !exists('g:templates_detect_git')
+	let g:templates_detect_git = 0
+endif
+
 " Put template system autocommands in their own group. {{{1
 if !exists('g:templates_no_autocmd')
 	let g:templates_no_autocmd = 0
@@ -360,10 +364,17 @@ function <SID>TExpandVars()
 
 	" Define license variable
 	if executable('licensee') && g:templates_use_licensee
+        let l:projectpath = shellescape(expand("%:p:h"))
+        if executable('git') && g:templates_detect_git
+            silent "!git rev-parse --is-inside-work-tree > /dev/null"
+            if v:shell_error == 0
+                let l:projectpath = system("git rev-parse --show-toplevel")
+            endif
+        endif
 		" Returns 'None' if the project does not have a license.
-		let l:license = matchstr(system("licensee detect " . shellescape(expand("%:p:h"))), '^License:\s*\zs\S\+\ze\%x00')
+		let l:license = matchstr(system("licensee detect " . l:projectpath), '^License:\s*\zs\S\+\ze\%x00')
 	endif
-	if !exists("l:license") || l:license == "None"
+	if !exists("l:license") || l:license == "None" || l:license == ""
 		if exists("g:license")
 			let l:license = g:license
 		else


### PR DESCRIPTION
There isn't an issue for this, but I needed this behavior for myself, so I figured I should open a pull request in case other people want to see it in the main project.

In short, I have an AGPL project I'm starting, and creating any file not in the root of the repository causes %LICENSE% to be replaced with "MIT" instead of "AGPL-3.0".

If there's a better way to implement this, I'm willing to do that as well. I thought of checking each subsequent parent directory in a loop, but thought that would too likely run into issues and delays. This is also my first time writing Vimscript, so there's probably things that can be improved.

Commit description:

The current implementation of using licensee to detect a project's
license only works in the root of a project, when the LICENSE file is a
sibling to the file being created.

More often than not, when a project is in a Git repository, there is a
singular file at the root of the project that applies to all files in
all child folders too. This commit uses the Git binary to determine the
root path of the project and passes that to licensee instead of the
directory containing the file being created.

Because this behavior adds a half-second delay to (Neo)Vim opening, it
is disabled by default and can be enabled by setting
`g:templates_detect_git` to `1`.