### PR TITLE
Don't rely on "v:shell_error" when detecting whether in git repo

### DIFF
--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -366,8 +366,8 @@ function <SID>TExpandVars()
 	if executable('licensee') && g:templates_use_licensee
         let l:projectpath = shellescape(expand("%:p:h"))
         if executable('git') && g:templates_detect_git
-            silent "!git rev-parse --is-inside-work-tree > /dev/null"
-            if v:shell_error == 0
+            let l:isgitrepo = matchstr(system("git rev-parse --is-inside-work-tree"), "true")
+            if l:isgitrepo == "true"
                 let l:projectpath = system("git rev-parse --show-toplevel")
             endif
         endif

--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -367,7 +367,7 @@ function <SID>TExpandVars()
         let l:projectpath = shellescape(expand("%:p:h"))
         if executable('git') && g:templates_detect_git
             let l:isgitrepo = matchstr(system("git rev-parse --is-inside-work-tree"), "true")
-            if l:isgitrepo == "true"
+            if l:isgitrepo ==# "true"
                 let l:projectpath = system("git rev-parse --show-toplevel")
             endif
         endif


### PR DESCRIPTION
I was encountering issues like
```
"~/.vim/plugged/vim-template/templates/=template=.sh" 10L, 127C
Error detected while processing function <SNR>58_TLoad[20]..<SNR>58_TLoadTemplate[14]..<SNR>58_TExpandVars:
line   34:
E484: Can't open file /tmp/vNG6Wyk/6
Press ENTER or type command to continue
```

when opening files outside of git repos and tracked the issue down to the fact that for whatever reason
```
silent "!git rev-parse --is-inside-work-tree > /dev/null"
```
wasn't changing `v:shell_error`.

Instead of relying on that behavior I instead use the output of
```
git rev-parse --is-inside-work-tree
```
and whether it evaluates to `true`.  This solves the issues I was encountering when opening files outside of git repos.