### PR TITLE
Remove coding tag in Python template

### DIFF
--- a/templates/=template=.py
+++ b/templates/=template=.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python3
-# -*- coding: utf-8 -*-
 # vim:fenc=utf-8
 #
 # Copyright © %YEAR% %USER% <%MAIL%>


### PR DESCRIPTION
The use of the coding tag is detailed in [PEP 263](https://peps.python.org/pep-0263/) oriented to Python 2. As Python 2 is currently at its end of life and this template is specific to Python 3, it is no longer necessary to specify the coding as indicated in PEP 8 in the [Source File Encoding](https://peps.python.org/pep-0008/#source-file-encoding) section.

What is not so clear to me is whether or not the vim tag `vim:fenc=utf-8` is still necessary. Supposedly according to PEP 8:
> Code in the core Python distribution should always use UTF-8, and should not have an encoding declaration

This would indicate that it should not be necessary either. But of course, this tag is for vim, not for Python. If you consider that it can be removed also comment it to me and I modify the merge request.