### PR TITLE
fix single slash inside double quotes

### DIFF
--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -535,7 +535,7 @@ execute "au BufNewFile,BufRead " . g:templates_name_prefix . "* "
 
 if !g:templates_no_builtin_templates
 	execute "au BufNewFile,BufRead "
-				\. s:default_template_dir . (has('win32') ? "\" : "/") . g:templates_global_name_prefix . "* "
+				\. s:default_template_dir . (!exists("+shellslash") || &shellslash ? '/' : '\') . g:templates_global_name_prefix . "* "
 				\. "let b:vim_template_subtype = &filetype | "
 				\. "set ft=vim-template"
 endif
@@ -544,7 +544,7 @@ for s:directory in g:templates_directory
 	let s:directory = <SID>NormalizePath(expand(s:directory) . '/')
 	if isdirectory(s:directory)
 		execute "au BufNewFile,BufRead "
-					\. s:directory . (has('win32') ? "\" : "/") . g:templates_global_name_prefix . "* "
+					\. s:directory . (!exists("+shellslash") || &shellslash ? '/' : '\') . g:templates_global_name_prefix . "* "
 					\. "let b:vim_template_subtype = &filetype | "
 					\. "set ft=vim-template"
 	endif


### PR DESCRIPTION
@aperezdc I beg your pardon, after blissfully applying the fix I had an odd feeling that maybe either `'\'` or `"\\"` be used as `"` allows for special characters such as `"\n"`, and so it is. At this occasion, I replaced the check by the most robust one, used by Tim Pope, say in https://github.com/tpope/vim-vinegar/